### PR TITLE
Add lod in cell data

### DIFF
--- a/Plugin/CityJSONReader/vtkCityJSONReader.cxx
+++ b/Plugin/CityJSONReader/vtkCityJSONReader.cxx
@@ -3,6 +3,7 @@
 // VTK Includes
 #include "vtkCellArray.h"
 #include "vtkCellData.h"
+#include "vtkFloatArray.h"
 #include "vtkDoubleArray.h"
 #include "vtkCityJSONFeature.h"
 #include "vtkInformation.h"
@@ -49,6 +50,12 @@ void vtkCityJSONReader::CityJSONReaderInternal::ParseRoot(const Json::Value &roo
     objectTypeArray->SetName("object-type");
     output->GetCellData()->AddArray(objectTypeArray);
     objectTypeArray->Delete();
+
+     // Initialize lod array used to store object type names
+    vtkFloatArray *lodArray = vtkFloatArray::New();
+    lodArray->SetName("lod");
+    output->GetCellData()->AddArray(lodArray);
+    lodArray->Delete();
 
     // Check type of root to ensure we're looking at a CityJSON file
     Json::Value rootType = root["type"];


### PR DESCRIPTION
Hello, 
Thanks for sharing this code!
I found it quite useful but it misses a few features. Is it still in use?

As CityJSON files can contain several LoDs for the same area, I suggest to add it as a cell Data. I made it a float value in order to be able to use a threshold filter to visualize a single LoD.

I've tested this change with paraview 5.11 on Ubuntu 22.04